### PR TITLE
feat: add configurable template question mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,8 @@ templates:
     path: job.yaml
 
 questions:
+  # テンプレート名を決定する質問を明示的に指定（新機能）
+  template_question: "app"
   # 質問の実行順序を明示的に指定
   order:
     - app
@@ -213,6 +215,7 @@ questions:
 
 ```yaml
 questions:
+  template_question: "something-1"  # どの質問がテンプレート名を決定するかを指定
   order:
     - something-1
     - something-2
@@ -246,6 +249,37 @@ questions:
         - production
 ```
 
+**テンプレート質問の指定機能（新機能）:**
+
+従来はヒューリスティック（最初のnon-multiple質問）でテンプレート名を決定していましたが、
+`template_question`フィールドで明示的に指定できるようになりました:
+
+```yaml
+questions:
+  template_question: "appType"  # この質問の回答がテンプレート名になる
+  order:
+    - region      # 地域選択（multiple可能）
+    - appType     # アプリタイプ（テンプレート決定）
+    - env         # 環境選択（multiple）
+  definitions:
+    region:
+      prompt: "地域を選択してください"
+      type:
+        multiple: true
+      choices: ["us-east", "us-west", "eu-west"]
+    appType:
+      prompt: "アプリケーションタイプは？"
+      choices: ["web-service", "batch-job", "microservice"]
+    env:
+      prompt: "環境は？"
+      type:
+        multiple: true
+      choices: ["dev", "staging", "prod"]
+```
+
+この場合、`appType`の回答（例: "web-service"）がテンプレート名として使用され、
+対応するテンプレートファイル（`.yg/_templates/web-service.yaml`）が読み込まれます。
+
 **下位互換性:**
 従来の直接指定形式も引き続きサポートされます:
 
@@ -260,6 +294,9 @@ questions:
       multiple: true
     choices: ["dev", "prod"]
 ```
+
+`template_question`が指定されていない場合は、従来通りのヒューリスティック
+（質問順序で最初のnon-multiple質問）でテンプレート名を決定します。
 
 ## テンプレートファイル
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ YAML template generator - A CLI tool to generate YAML files from templates based
 - **Signal Handling**: Graceful shutdown with Ctrl+C
 - **Directory Templates**: Support for multi-file template directories 🆕
 - **File Templates**: Traditional single-file template support (backward compatible)
+- **Template Question Control**: Configure which question determines template selection 🆕
 
 ## Installation
 
@@ -108,49 +109,57 @@ templates:
 
 # Question configuration
 questions:
-  app:
-    prompt: "アプリの種類はなんですか？"
-    choices:
-      - microservice   # Directory template
-      - deployment    # File template
-      - job          # File template
-  appName:
-    prompt: "アプリ名は何ですか？"
-    type:
-      dynamic:
-        dependency_questions: ["app"]
-      interactive: true
-    choices:
-      microservice:
-        - sample-api-1
-        - sample-api-2
-      deployment:
-        - sample-server-1
-        - sample-server-2
-      job:
-        - sample-job-1
-        - sample-job-2
-  env:
-    prompt: "環境名はなんですか？"
-    multiple: true
-    choices:
-      - dev
-      - staging
-      - production
-  cluster:
-    prompt: "クラスターはどこですか？"
-    multiple: true
-    type:
-      dynamic:
-        dependency_questions: ["env"]
-    choices:
-      dev:
-        - dev-cluster-1
-        - dev-cluster-2
-      staging:
-        - staging-cluster-1
-      production:
-        - production-cluster-1
+  template_question: "app"  # Which question determines template selection 🆕
+  order:                    # Question execution order 🆕
+    - app
+    - appName
+    - env
+    - cluster
+  definitions:             # Question definitions 🆕
+    app:
+      prompt: "アプリの種類はなんですか？"
+      choices:
+        - microservice   # Directory template
+        - deployment    # File template
+        - job          # File template
+    appName:
+      prompt: "アプリ名は何ですか？"
+      type:
+        dynamic:
+          dependency_questions: ["app"]
+        interactive: true
+      choices:
+        microservice:
+          - sample-api-1
+          - sample-api-2
+        deployment:
+          - sample-server-1
+          - sample-server-2
+        job:
+          - sample-job-1
+          - sample-job-2
+    env:
+      prompt: "環境名はなんですか？"
+      type:
+        multiple: true
+      choices:
+        - dev
+        - staging
+        - production
+    cluster:
+      prompt: "クラスターはどこですか？"
+      type:
+        multiple: true
+        dynamic:
+          dependency_questions: ["env"]
+      choices:
+        dev:
+          - dev-cluster-1
+          - dev-cluster-2
+        staging:
+          - staging-cluster-1
+        production:
+          - production-cluster-1
 ```
 
 ### Template Files
@@ -193,6 +202,40 @@ files:
 ```
 
 Each file in the directory is a regular Go template without metadata headers.
+
+### Template Question Configuration 🆕
+
+The `template_question` field allows you to explicitly specify which question determines the template selection:
+
+```yaml
+questions:
+  template_question: "serviceType"  # Specify which question provides template name
+  order:
+    - region                        # First question (multiple selection)
+    - serviceType                   # This determines template
+    - environment                   # Last question (multiple selection)
+  definitions:
+    region:
+      prompt: "Select regions"
+      type:
+        multiple: true
+      choices: ["us-east", "us-west", "eu-west"]
+    serviceType:
+      prompt: "Service type?"
+      choices: ["web-app", "api-service", "batch-job"]
+    environment:
+      prompt: "Target environments"
+      type:
+        multiple: true
+      choices: ["dev", "staging", "prod"]
+```
+
+**Benefits:**
+- **Flexible ordering**: Template-determining question doesn't need to be first
+- **Clear configuration**: Explicit rather than heuristic-based template selection
+- **Backward compatible**: Falls back to original heuristic if not specified
+
+**Fallback behavior**: If `template_question` is not specified, the system uses the first non-multiple question in order (original behavior).
 
 ## Examples
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,8 +23,9 @@ type TemplateConfig struct {
 
 // Questions represents the questions configuration with order and definitions.
 type Questions struct {
-	Order       []string            `yaml:"order,omitempty"`
-	Definitions map[string]Question `yaml:"definitions,omitempty"`
+	Order            []string            `yaml:"order,omitempty"`
+	TemplateQuestion string              `yaml:"template_question,omitempty"`
+	Definitions      map[string]Question `yaml:"definitions,omitempty"`
 	// For backward compatibility, support the old direct map format
 	DirectMap map[string]Question `yaml:",inline"`
 }
@@ -117,6 +118,12 @@ func (q *Questions) GetOrder() []string {
 		order = append(order, key)
 	}
 	return order
+}
+
+// GetTemplateQuestion returns the question key that provides the template name.
+// If not specified, returns empty string and the caller should use heuristics.
+func (q *Questions) GetTemplateQuestion() string {
+	return q.TemplateQuestion
 }
 
 // normalize handles backward compatibility by moving direct map to definitions if needed.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,20 +7,8 @@ import (
 )
 
 const (
-	testAppPrompt = "アプリの種類はなんですか？"
-)
-
-func TestLoadConfig(t *testing.T) {
-	// Create temporary config directory and file
-	tempDir := t.TempDir()
-	configDir := filepath.Join(tempDir, ".yg", "_templates")
-	err := os.MkdirAll(configDir, 0755)
-	if err != nil {
-		t.Fatalf("Failed to create temp config directory: %v", err)
-	}
-
-	configFile := filepath.Join(configDir, ".yg-config.yaml")
-	configContent := `questions:
+	testAppPrompt     = "アプリの種類はなんですか？"
+	testConfigContent = `questions:
   definitions:
     app:
       prompt: "アプリの種類はなんですか？"
@@ -38,6 +26,19 @@ func TestLoadConfig(t *testing.T) {
     - app
     - env
 `
+)
+
+func TestLoadConfig(t *testing.T) {
+	// Create temporary config directory and file
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, ".yg", "_templates")
+	err := os.MkdirAll(configDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create temp config directory: %v", err)
+	}
+
+	configFile := filepath.Join(configDir, ".yg-config.yaml")
+	configContent := testConfigContent
 
 	err = os.WriteFile(configFile, []byte(configContent), 0600)
 	if err != nil {
@@ -837,24 +838,7 @@ func TestLoadConfigWithoutTemplateQuestion(t *testing.T) {
 	}
 
 	configFile := filepath.Join(configDir, "config.yaml")
-	configContent := `questions:
-  definitions:
-    app:
-      prompt: "アプリの種類はなんですか？"
-      choices:
-        - deployment
-        - job
-    env:
-      prompt: "環境名はなんですか？"
-      type:
-        multiple: true
-      choices:
-        - dev
-        - staging
-  order:
-    - app
-    - env
-`
+	configContent := testConfigContent
 
 	err = os.WriteFile(configFile, []byte(configContent), 0600)
 	if err != nil {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -186,7 +186,10 @@ func (g *Generator) determineTemplateAndMultiValues() (string, map[string][]stri
 		if str, ok := answer.(string); ok {
 			templateType = str
 		} else {
-			return "", nil, fmt.Errorf("template question '%s' must have a single string answer, got %T", templateQuestionKey, answer)
+			return "", nil, fmt.Errorf(
+				"template question '%s' must have a single string answer, got %T",
+				templateQuestionKey, answer,
+			)
 		}
 	} else {
 		// Fall back to heuristic: first non-multi question as template type

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9,6 +9,23 @@ import (
 
 const (
 	testAppTypeDeployment = "deployment"
+	testDeploymentContent = `path: {{.Questions.env}}/{{.Questions.cluster}}/deployment
+filename: {{.Questions.appName}}-deployment.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Questions.appName}}
+  namespace: {{.Questions.env}}`
+
+	testJobContent = `path: {{.Questions.env}}/{{.Questions.cluster}}/job
+filename: {{.Questions.appName}}-job.yaml
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.Questions.appName}}
+  namespace: {{.Questions.env}}`
 )
 
 // MockPrompter implements PrompterInterface for testing
@@ -136,14 +153,7 @@ func setupTestEnvironment(t *testing.T) string {
 
 	// Create template files
 	deploymentTemplate := filepath.Join(templateDir, "deployment.yaml")
-	deploymentContent := `path: {{.Questions.env}}/{{.Questions.cluster}}/deployment
-filename: {{.Questions.appName}}-deployment.yaml
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{.Questions.appName}}
-  namespace: {{.Questions.env}}`
+	deploymentContent := testDeploymentContent
 
 	err = os.WriteFile(deploymentTemplate, []byte(deploymentContent), 0644)
 	if err != nil {
@@ -151,14 +161,7 @@ metadata:
 	}
 
 	jobTemplate := filepath.Join(templateDir, "job.yaml")
-	jobContent := `path: {{.Questions.env}}/{{.Questions.cluster}}/job
-filename: {{.Questions.appName}}-job.yaml
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: {{.Questions.appName}}
-  namespace: {{.Questions.env}}`
+	jobContent := testJobContent
 
 	err = os.WriteFile(jobTemplate, []byte(jobContent), 0644)
 	if err != nil {
@@ -721,14 +724,7 @@ func setupTestEnvironmentWithTemplateQuestion(t *testing.T) string {
 
 	// Create template files
 	deploymentTemplate := filepath.Join(templateDir, "deployment.yaml")
-	deploymentContent := `path: {{.Questions.env}}/{{.Questions.cluster}}/deployment
-filename: {{.Questions.appName}}-deployment.yaml
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{.Questions.appName}}
-  namespace: {{.Questions.env}}`
+	deploymentContent := testDeploymentContent
 
 	err = os.WriteFile(deploymentTemplate, []byte(deploymentContent), 0644)
 	if err != nil {
@@ -736,14 +732,7 @@ metadata:
 	}
 
 	jobTemplate := filepath.Join(templateDir, "job.yaml")
-	jobContent := `path: {{.Questions.env}}/{{.Questions.cluster}}/job
-filename: {{.Questions.appName}}-job.yaml
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: {{.Questions.appName}}
-  namespace: {{.Questions.env}}`
+	jobContent := testJobContent
 
 	err = os.WriteFile(jobTemplate, []byte(jobContent), 0644)
 	if err != nil {


### PR DESCRIPTION
Fixes #13

This PR implements the ability to configure which question determines template selection using the `template_question` field.

## Changes
- Added `template_question` field to Questions struct
- Updated generator logic to use configured template question
- Maintained backward compatibility with existing configurations
- Added comprehensive test coverage
- Updated documentation with usage examples

## Benefits
- More flexible question ordering
- Explicit template selection configuration
- Better user control over template resolution

Generated with [Claude Code](https://claude.ai/code)