### PR TITLE
fix: 質問の依存関係に応じて選択肢を変えたい

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -247,27 +247,6 @@ func (g *Generator) generateCombinations(multiValueQuestions map[string][]string
 	return combinations
 }
 
-func (g *Generator) generateCombinationsRecursive(
-	keys []string, values [][]string, index int,
-	current map[string]string, result *[]map[string]interface{},
-) {
-	if index >= len(keys) {
-		// Create a copy of the base answers and override with current combination
-		combination := g.copyAnswers()
-		for key, value := range current {
-			combination[key] = value
-		}
-		*result = append(*result, combination)
-		return
-	}
-
-	for _, value := range values[index] {
-		current[keys[index]] = value
-		g.generateCombinationsRecursive(keys, values, index+1, current, result)
-	}
-	delete(current, keys[index]) // backtrack
-}
-
 func (g *Generator) copyAnswers() map[string]interface{} {
 	result := make(map[string]interface{})
 	for key, value := range g.answers {
@@ -278,7 +257,9 @@ func (g *Generator) copyAnswers() map[string]interface{} {
 
 // parseHierarchicalSelections parses choices that may contain hierarchical format (parent: child)
 // and returns a map of question keys to their possible value combinations
-func (g *Generator) parseHierarchicalSelections(multiValueQuestions map[string][]string) map[string][]map[string]string {
+func (g *Generator) parseHierarchicalSelections(
+	multiValueQuestions map[string][]string,
+) map[string][]map[string]string {
 	result := make(map[string][]map[string]string)
 
 	for questionKey, selections := range multiValueQuestions {


### PR DESCRIPTION
複数選択の依存関係において選択肢が平坦化される問題を修正。

## 変更内容
- config: 複数選択依存関係で "parent: child" 形式の選択肢を生成
- generator: 階層形式選択肢の解析と適切な組み合わせ生成を実装

## 効果
これにより、dev/stg選択時にdev階層とstg階層の選択肢が適切に分離され、出力時に正しい親子関係が保持されます。

Fixes #21

🤖 Generated with [Claude Code](https://claude.ai/code)